### PR TITLE
fix: enable passing `style` attribute to icons

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -37,7 +37,7 @@ export default (async () => {
     const styles = parseStyles(svg.getAttribute('style'))
 
     const component = `import React from 'react';
-const ${componentName} = ({ color = 'currentColor', size = 24, ...props }) => {
+const ${componentName} = ({ color = 'currentColor', size = 24, style, ...props }) => {
   return ${parseSvg(optimizedSvgString, styles)};
 }
 export default ${componentName};`
@@ -65,7 +65,7 @@ const parseSvg = (svg: string, styles: any) => {
   }
 
   svg = svg.replace(/-([a-z])(?=[a-z\-]*[=\s/>])/g, g => g[1].toUpperCase())
-  svg = svg.replace(/<svg([^>]+)>/, `<svg$1 {...props} height={size} width={size} style={{color}}>`)
+  svg = svg.replace(/<svg([^>]+)>/, `<svg$1 {...props} height={size} width={size} style={{...style,color}}>`)
 
   const geistFillColor = getSpecifiedColorVar(styles['--geist-fill'], 'current')
   const geistStrokeColor = getSpecifiedColorVar(styles['--geist-stroke'], 'current')


### PR DESCRIPTION
## Background
- `style` attributes are ignored because it's been overridden by `style={{color}}`. 

## Changes
- Fixing it to pass all styles except `color`—Now you can pass styles to `Icon`!

```tsx
import { Info } from '@geist-ui/icons';

<Info
  size={20}
  style={{
    marginRight: 8,
    display: 'inline-block',
    verticalAlign: 'text-bottom',
  }}
/>
```

<img width="652" alt="image" src="https://user-images.githubusercontent.com/32605822/197400044-2f0340ec-d0fb-4b59-9499-841514625e5f.png">